### PR TITLE
Fix Duplicate Container Name in Docker Image URI

### DIFF
--- a/lib/etl-utils-stack.ts
+++ b/lib/etl-utils-stack.ts
@@ -229,7 +229,7 @@ export class EtlUtilsStack extends cdk.Stack {
         const ecrRepoArn = Fn.importValue(createBaseImportValue(stackNameComponent, BASE_EXPORT_NAMES.ECR_ETL_REPO));
         // Extract repository name from ARN (format: arn:aws:ecr:region:account:repository/name)
         const ecrRepoName = Fn.select(1, Fn.split('/', ecrRepoArn));
-        containerImageUri = `${this.account}.dkr.ecr.${this.region}.amazonaws.com/${cdk.Token.asString(ecrRepoName)}:${containerName}-${imageTag}`;
+        containerImageUri = `${this.account}.dkr.ecr.${this.region}.amazonaws.com/${cdk.Token.asString(ecrRepoName)}:${imageTag}`;
       }
 
       // Add environment variables for S3 config access


### PR DESCRIPTION
## Summary
Fixes duplicate container name prefix in CDK-generated Docker image URIs causing ECS deployment failures.

## Problem
CDK was constructing image URIs with duplicate container names where imageTag from workflows was already `ais-proxy-v2025-08-04`, resulting in `ais-proxy-ais-proxy-v2025-08-04`.

## Solution
Updated CDK to use image tag directly without adding container name prefix. Now produces correct image URIs like `ais-proxy-v2025-08-04` and `weather-proxy-v2025-08-04`.

## Files Changed
- `lib/etl-utils-stack.ts`
