### PR TITLE
Fix CDK Context Variable Naming for Image Tags

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -81,8 +81,8 @@ jobs:
             --context envType=prod \
             --context stackName=${{ vars.DEMO_STACK_NAME }} \
             --context usePreBuiltImages=true \
-            --context weather-proxyImageTag=${{ needs.build-images.outputs.weather-proxy-tag }} \
-            --context ais-proxyImageTag=${{ needs.build-images.outputs.ais-proxy-tag }} \
+            --context weatherProxyImageTag=${{ needs.build-images.outputs.weather-proxy-tag }} \
+            --context aisProxyImageTag=${{ needs.build-images.outputs.ais-proxy-tag }} \
             --require-approval never
 
       - name: Wait for Testing Period
@@ -122,6 +122,6 @@ jobs:
             --context envType=dev-test \
             --context stackName=${{ vars.DEMO_STACK_NAME }} \
             --context usePreBuiltImages=true \
-            --context weather-proxyImageTag=${{ needs.build-images.outputs.weather-proxy-tag }} \
-            --context ais-proxyImageTag=${{ needs.build-images.outputs.ais-proxy-tag }} \
+            --context weatherProxyImageTag=${{ needs.build-images.outputs.weather-proxy-tag }} \
+            --context aisProxyImageTag=${{ needs.build-images.outputs.ais-proxy-tag }} \
             --require-approval never

--- a/lib/etl-utils-stack.ts
+++ b/lib/etl-utils-stack.ts
@@ -226,7 +226,7 @@ export class EtlUtilsStack extends cdk.Stack {
       if (usePreBuiltImages) {
         // Convert container name to camelCase for context variable (weather-proxy -> weatherProxy)
         const contextVarName = containerName.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase()) + 'ImageTag';
-        const imageTag = this.node.tryGetContext(contextVarName) ?? containerConfig.imageTag;
+        const imageTag = this.node.tryGetContext(contextVarName) ?? containerConfig.imageTag ?? envConfig.docker.imageTag;
         // Get ECR repository ARN from BaseInfra and extract repository name
         const ecrRepoArn = Fn.importValue(createBaseImportValue(stackNameComponent, BASE_EXPORT_NAMES.ECR_ETL_REPO));
         // Extract repository name from ARN (format: arn:aws:ecr:region:account:repository/name)

--- a/lib/etl-utils-stack.ts
+++ b/lib/etl-utils-stack.ts
@@ -224,7 +224,9 @@ export class EtlUtilsStack extends cdk.Stack {
       // Determine container image URI for dual image strategy
       let containerImageUri: string | undefined;
       if (usePreBuiltImages) {
-        const imageTag = this.node.tryGetContext(`${containerName}ImageTag`) ?? envConfig.docker.imageTag;
+        // Convert container name to camelCase for context variable (weather-proxy -> weatherProxy)
+        const contextVarName = containerName.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase()) + 'ImageTag';
+        const imageTag = this.node.tryGetContext(contextVarName) ?? containerConfig.imageTag;
         // Get ECR repository ARN from BaseInfra and extract repository name
         const ecrRepoArn = Fn.importValue(createBaseImportValue(stackNameComponent, BASE_EXPORT_NAMES.ECR_ETL_REPO));
         // Extract repository name from ARN (format: arn:aws:ecr:region:account:repository/name)

--- a/lib/stack-config.ts
+++ b/lib/stack-config.ts
@@ -14,6 +14,7 @@ export interface ContainerConfig {
   cpu: number;
   memory: number;
   priority: number;
+  imageTag: string;
 }
 
 /**

--- a/test/stack-config.test.ts
+++ b/test/stack-config.test.ts
@@ -10,7 +10,8 @@ describe('Stack Configuration Types', () => {
         port: 3000,
         cpu: 256,
         memory: 512,
-        priority: 1
+        priority: 1,
+        imageTag: 'v1.0.0'
       };
 
       expect(containerConfig.enabled).toBe(true);
@@ -30,7 +31,8 @@ describe('Stack Configuration Types', () => {
         port: 8080,
         cpu: 128,
         memory: 256,
-        priority: 10
+        priority: 10,
+        imageTag: 'v1.0.0'
       };
 
       expect(containerConfig.enabled).toBe(false);
@@ -44,7 +46,8 @@ describe('Stack Configuration Types', () => {
         port: 3000,
         cpu: 256,
         memory: 512,
-        priority: 1
+        priority: 1,
+        imageTag: 'v1.0.0'
       };
       
       expect(typeof config.enabled).toBe('boolean');
@@ -77,7 +80,8 @@ describe('Stack Configuration Types', () => {
             port: 3000,
             cpu: 256,
             memory: 512,
-            priority: 1
+            priority: 1,
+            imageTag: 'v1.0.0'
           }
         },
         general: {
@@ -121,7 +125,8 @@ describe('Stack Configuration Types', () => {
             port: 3000,
             cpu: 512,
             memory: 1024,
-            priority: 1
+            priority: 1,
+            imageTag: 'v1.0.0'
           },
           'container-2': {
             enabled: false,
@@ -130,7 +135,8 @@ describe('Stack Configuration Types', () => {
             port: 4000,
             cpu: 256,
             memory: 512,
-            priority: 2
+            priority: 2,
+            imageTag: 'v1.0.0'
           }
         },
         general: {
@@ -167,7 +173,8 @@ describe('Stack Configuration Types', () => {
             port: 3000,
             cpu: 256,
             memory: 512,
-            priority: 1
+            priority: 1,
+            imageTag: 'v1.0.0'
           }
         },
         general: {


### PR DESCRIPTION
## Summary
Fixes empty image tag issue in ECS deployments by correcting CDK context variable naming convention.

## Problem
CDK context variables cannot contain hyphens, but workflows were passing `weather-proxyImageTag` which CDK couldn't access properly. This resulted in empty image tags and ECS deployment failures with malformed image URIs.

## Solution
- Updated GitHub workflows to use camelCase context variables: `weatherProxyImageTag`, `aisProxyImageTag`
- Modified CDK stack to convert hyphenated container names to camelCase for context lookup
- Fixed fallback to use container-specific `imageTag` from configuration

## Changes
- `demo-deploy.yml`: Updated context variable names to camelCase
- `etl-utils-stack.ts`: Added conversion logic for hyphenated container names to camelCase context variables
