### PR TITLE
Fix Image Tag Resolution and Test Configuration

### DIFF
--- a/lib/etl-utils-stack.ts
+++ b/lib/etl-utils-stack.ts
@@ -226,7 +226,14 @@ export class EtlUtilsStack extends cdk.Stack {
       if (usePreBuiltImages) {
         // Convert container name to camelCase for context variable (weather-proxy -> weatherProxy)
         const contextVarName = containerName.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase()) + 'ImageTag';
-        const imageTag = this.node.tryGetContext(contextVarName) ?? containerConfig.imageTag;
+        const contextImageTag = this.node.tryGetContext(contextVarName);
+        const configImageTag = containerConfig.imageTag;
+        const imageTag = contextImageTag ?? configImageTag;
+        
+        if (!imageTag) {
+          throw new Error(`No image tag found for container '${containerName}'. Context '${contextVarName}': ${contextImageTag}, Config: ${configImageTag}`);
+        }
+        
         // Get ECR repository ARN from BaseInfra and extract repository name
         const ecrRepoArn = Fn.importValue(createBaseImportValue(stackNameComponent, BASE_EXPORT_NAMES.ECR_ETL_REPO));
         // Extract repository name from ARN (format: arn:aws:ecr:region:account:repository/name)

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -47,7 +47,8 @@ export function createTestApp(): cdk.App {
             port: 3000,
             cpu: 256,
             memory: 512,
-            priority: 1
+            priority: 1,
+            imageTag: 'v2025-08-04'
           },
           'ais-proxy': {
             enabled: true,
@@ -56,7 +57,8 @@ export function createTestApp(): cdk.App {
             port: 3000,
             cpu: 256,
             memory: 512,
-            priority: 2
+            priority: 2,
+            imageTag: 'v2025-08-04'
           }
         },
         general: {
@@ -67,8 +69,7 @@ export function createTestApp(): cdk.App {
           enableEcsExec: false
         },
         docker: {
-          usePreBuiltImages: false,
-          imageTag: 'latest'
+          usePreBuiltImages: false
         }
       },
       'prod': {
@@ -82,7 +83,8 @@ export function createTestApp(): cdk.App {
             port: 3000,
             cpu: 512,
             memory: 1024,
-            priority: 1
+            priority: 1,
+            imageTag: 'v2025-08-04'
           },
           'ais-proxy': {
             enabled: true,
@@ -91,7 +93,8 @@ export function createTestApp(): cdk.App {
             port: 3000,
             cpu: 512,
             memory: 1024,
-            priority: 2
+            priority: 2,
+            imageTag: 'v2025-08-04'
           }
         },
         general: {
@@ -102,8 +105,7 @@ export function createTestApp(): cdk.App {
           enableEcsExec: true
         },
         docker: {
-          usePreBuiltImages: true,
-          imageTag: 'v1.0.0'
+          usePreBuiltImages: true
         }
       },
       'tak-defaults': {


### PR DESCRIPTION
## Summary
Fixes empty image tag issue causing ECS deployment failures by ensuring proper image tag resolution in both tests and runtime.

## Problem
ECS was receiving malformed image URIs with empty tags causing deployment failures. Tests were also failing because container configurations were missing imageTag properties.

## Root Cause
The test configuration in utils.ts was missing imageTag properties in container configs, causing containerConfig.imageTag to be undefined. This exposed that the fallback chain wasn't working properly.

## Solution
- Added imageTag properties to all container configurations in test utils
- Added error handling in CDK stack to fail fast with clear error messages if image tags are missing
- Removed old docker.imageTag references from test configurations
- Ensured proper fallback chain: context variable → container imageTag

## Changes
- `test/utils.ts`: Added imageTag to container configurations, removed from docker section
- `lib/etl-utils-stack.ts`: Added error handling for missing image tags
