### PR TITLE
Fix GitHub Actions JSON Formatting Issues

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -128,16 +128,17 @@ jobs:
             
           done <<< "${{ steps.containers.outputs.enabled-containers }}"
           
-          # Output JSON for deploy workflows
-          echo "image-tags-json=$IMAGE_TAGS_JSON" >> $GITHUB_OUTPUT
-          echo "Built image tags: $IMAGE_TAGS_JSON"
+          # Output JSON for deploy workflows (compact format for GitHub Actions)
+          COMPACT_JSON=$(echo $IMAGE_TAGS_JSON | jq -c .)
+          echo "image-tags-json=$COMPACT_JSON" >> $GITHUB_OUTPUT
+          echo "Built image tags: $COMPACT_JSON"
           
 
       
       - name: Output Image Information
         run: |
           echo "✅ Successfully built and pushed Docker images:"
-          echo "${{ steps.build.outputs.image-tags-json }}" | jq -r 'to_entries[] | "📦 \(.key): \(.value)"'
+          echo '${{ steps.build.outputs.image-tags-json }}' | jq -r 'to_entries[] | "📦 \(.key): \(.value)"'
           echo ""
           echo "🚀 To deploy with these images, use:"
           echo "npm run cdk deploy -- --context usePreBuiltImages=true --context imageTagsJson='${{ steps.build.outputs.image-tags-json }}'"

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -123,16 +123,17 @@ jobs:
             
           done <<< "${{ steps.containers.outputs.enabled-containers }}"
           
-          # Output JSON for deploy workflows
-          echo "image-tags-json=$IMAGE_TAGS_JSON" >> $GITHUB_OUTPUT
-          echo "Built image tags: $IMAGE_TAGS_JSON"
+          # Output JSON for deploy workflows (compact format for GitHub Actions)
+          COMPACT_JSON=$(echo $IMAGE_TAGS_JSON | jq -c .)
+          echo "image-tags-json=$COMPACT_JSON" >> $GITHUB_OUTPUT
+          echo "Built image tags: $COMPACT_JSON"
           
 
       
       - name: Output Image Information
         run: |
           echo "✅ Successfully built and pushed Docker images:"
-          echo "${{ steps.build.outputs.image-tags-json }}" | jq -r 'to_entries[] | "📦 \(.key): \(.value)"'
+          echo '${{ steps.build.outputs.image-tags-json }}' | jq -r 'to_entries[] | "📦 \(.key): \(.value)"'
           echo ""
           echo "🚀 To deploy with these images, use:"
           echo "npm run cdk deploy -- --context usePreBuiltImages=true --context imageTagsJson='${{ steps.build.outputs.image-tags-json }}'"


### PR DESCRIPTION
## Problem
Build workflows were failing with JSON formatting errors due to multiline JSON output being incompatible with GitHub Actions output variables.

## Root Cause
- GitHub Actions output variables don't handle multiline JSON properly
- Shell interpretation of JSON with special characters caused parsing errors
- Pretty-printed JSON format caused invalid format errors

## Solution
- Use jq -c to create compact JSON without newlines
- Use single quotes around JSON variables to prevent shell interpretation
- Ensure consistent JSON formatting across both build workflows

## Changes
### Build Workflows (demo-build.yml, production-build.yml)
- Add compact JSON formatting with jq -c
- Fix shell quoting for JSON output parsing
- Maintain readable logging while fixing GitHub Actions compatibility

## Testing
- Verified compact JSON format works with GitHub Actions
- Confirmed JSON parsing in output steps works correctly
- Tested with existing container configurations

## Impact
- Fixes build workflow failures
- Maintains all existing functionality
- Ensures reliable CI/CD pipeline operation
