### PR TITLE
Standardize Map Source Naming Convention

### DIFF
--- a/tileserver-helper/maps-package/template/GoogleMaps.xml
+++ b/tileserver-helper/maps-package/template/GoogleMaps.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <customMapSource>
-  <name>5 - Google Maps - Standard</name>
+  <name>05 - Google Maps - Standard</name>
   <minZoom>0</minZoom>
   <maxZoom>18</maxZoom>
   <tileType>png</tileType>

--- a/tileserver-helper/maps-package/template/GoogleMapsHybrid.xml
+++ b/tileserver-helper/maps-package/template/GoogleMapsHybrid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <customMapSource>
-  <name>6 - Google Maps - Hybrid</name>
+  <name>06 - Google Maps - Hybrid</name>
   <minZoom>0</minZoom>
   <maxZoom>18</maxZoom>
   <tileType>png</tileType>

--- a/tileserver-helper/maps-package/template/GoogleMapsSatellite.xml
+++ b/tileserver-helper/maps-package/template/GoogleMapsSatellite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <customMapSource>
-  <name>7 - Google Maps - Satellite</name>
+  <name>07 - Google Maps - Satellite</name>
   <minZoom>0</minZoom>
   <maxZoom>18</maxZoom>
   <tileType>png</tileType>

--- a/tileserver-helper/maps-package/template/GoogleMapsTerrain.xml
+++ b/tileserver-helper/maps-package/template/GoogleMapsTerrain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <customMapSource>
-  <name>8 - Google Maps - Terrain</name>
+  <name>08 - Google Maps - Terrain</name>
   <minZoom>0</minZoom>
   <maxZoom>18</maxZoom>
   <tileType>png</tileType>

--- a/tileserver-helper/maps-package/template/GoogleMapsTraffic.xml
+++ b/tileserver-helper/maps-package/template/GoogleMapsTraffic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <customMapSource>
-  <name>9 - Google Maps - Traffic</name>
+  <name>09 - Google Maps - Traffic</name>
   <minZoom>0</minZoom>
   <maxZoom>18</maxZoom>
   <tileType>png</tileType>

--- a/tileserver-helper/maps-package/template/LINZ-TopoGridless.xml
+++ b/tileserver-helper/maps-package/template/LINZ-TopoGridless.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <customMapSource>
-    <name>3 - TAK.NZ - LINZ Topo Gridless</name>
+    <name>03 - TAK.NZ - LINZ Topo Gridless</name>
     <minZoom>0</minZoom>
     <maxZoom>14</maxZoom>
     <tileType>png</tileType>

--- a/tileserver-helper/maps-package/template/LINZ-Topographic.xml
+++ b/tileserver-helper/maps-package/template/LINZ-Topographic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <customMapSource>
-    <name>1 - TAK.NZ - LINZ Topographic</name>
+    <name>01 - TAK.NZ - LINZ Topographic</name>
     <minZoom>0</minZoom>
     <maxZoom>20</maxZoom>
     <tileType>png</tileType>

--- a/tileserver-helper/maps-package/template/LINZ-Topolite.xml
+++ b/tileserver-helper/maps-package/template/LINZ-Topolite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <customMapSource>
-    <name>2 - TAK.NZ - LINZ Topolite</name>
+    <name>02 - TAK.NZ - LINZ Topolite</name>
     <minZoom>0</minZoom>
     <maxZoom>20</maxZoom>
     <tileType>png</tileType>

--- a/tileserver-helper/maps-package/template/NZ-National-Map-Emergency-Management.xml
+++ b/tileserver-helper/maps-package/template/NZ-National-Map-Emergency-Management.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <customMapSource>
-    <name>4 - TAK.NZ - NZ National Map Emergency Management</name>
+    <name>04 - TAK.NZ - NZ National Map Emergency Management</name>
     <minZoom>0</minZoom>
     <maxZoom>20</maxZoom>
     <tileType>png</tileType>


### PR DESCRIPTION
### Changes
- Updated all map template XML files to use zero-padded numeric prefixes (e.g., "05 -" instead of "5 -")
- Ensures consistent alphabetical sorting in map selection interfaces
- Affects Google Maps variants and LINZ topographic map templates

### Files Modified
- All template XML files in `tileserver-helper/maps-package/template/`

### Impact
- Improves user experience with predictable map ordering
- No functional changes to map functionality
- Maintains backward compatibility
