### PR TITLE
Add Marinesia API as vessel data source for AIS proxy

### DIFF
--- a/ais-proxy/server.js
+++ b/ais-proxy/server.js
@@ -537,17 +537,15 @@ function processAISMessage(message) {
         vessel.NAME = marinesiaVessel.name;
         vessel._nameSource = 'marinesia';
       }
-      if (vessel.TYPE === null && marinesiaVessel.type !== null) {
+      if ((vessel.TYPE === null || vessel.TYPE === 0) && marinesiaVessel.type !== null) {
         vessel.TYPE = marinesiaVessel.type;
       }
       if (!vessel.IMO && marinesiaVessel.imo) vessel.IMO = marinesiaVessel.imo;
       if (!vessel.CALLSIGN && marinesiaVessel.callsign) vessel.CALLSIGN = marinesiaVessel.callsign;
       if (!vessel.DEST && marinesiaVessel.dest) vessel.DEST = marinesiaVessel.dest;
       if (!vessel.DRAUGHT && marinesiaVessel.draught) vessel.DRAUGHT = marinesiaVessel.draught;
-      if (vessel.A === null && marinesiaVessel.a) vessel.A = marinesiaVessel.a;
-      if (vessel.B === null && marinesiaVessel.b) vessel.B = marinesiaVessel.b;
-      if (vessel.C === null && marinesiaVessel.c) vessel.C = marinesiaVessel.c;
-      if (vessel.D === null && marinesiaVessel.d) vessel.D = marinesiaVessel.d;
+      if ((vessel.A === null || vessel.A === 0) && marinesiaVessel.a) { vessel.A = marinesiaVessel.a; vessel.B = marinesiaVessel.b; }
+      if ((vessel.C === null || vessel.C === 0) && marinesiaVessel.c) { vessel.C = marinesiaVessel.c; vessel.D = marinesiaVessel.d; }
     }
     
     // Save cache occasionally
@@ -1358,11 +1356,13 @@ let marinesiaInterval = null;
 
 // Map Marinesia type text to AIS type codes
 const MARINESIA_TYPE_MAP = {
-  'cargo': 70, 'tanker': 80, 'passenger': 60, 'fishing': 30,
+  'tanker': 80, 'cargo': 70, 'passenger': 60, 'fishing': 30,
   'tug': 52, 'towing': 52, 'pilot': 50, 'pleasure craft': 37,
-  'sailing': 36, 'military': 35, 'search and rescue': 51,
-  'high speed craft': 40, 'dredging': 33, 'diving': 33,
-  'law enforcement': 55, 'wing in ground (wig)': 20
+  'sailing': 36, 'military': 35, 'high speed craft': 40,
+  'search and rescue': 51, 'law enforcement': 55,
+  'dredging': 33, 'diving': 33, 'supply ship': 79,
+  'wing in ground (wig)': 20, 'port tender': 53, 'anti-pollution': 54,
+  'medical': 58
 };
 
 async function pollMarinesia() {
@@ -1414,18 +1414,21 @@ async function pollMarinesia() {
 
       // Immediately enrich any cached vessel missing data
       const cached = vesselCache.get(v.mmsi);
-      if (cached && !cached.NAME && v.name) {
-        cached.NAME = v.name;
-        cached._nameSource = 'marinesia';
-        enriched++;
+      if (cached) {
+        if (!cached.NAME && v.name) {
+          cached.NAME = v.name;
+          cached._nameSource = 'marinesia';
+          enriched++;
+        }
+        if ((cached.TYPE === null || cached.TYPE === 0) && MARINESIA_TYPE_MAP[typeKey] !== undefined) {
+          cached.TYPE = MARINESIA_TYPE_MAP[typeKey];
+        }
+        if (!cached.IMO && v.imo) cached.IMO = v.imo;
+        if (!cached.DEST && v.dest) cached.DEST = v.dest;
+        if (!cached.DRAUGHT && v.draught) cached.DRAUGHT = v.draught;
+        if ((cached.A === null || cached.A === 0) && v.a) { cached.A = v.a; cached.B = v.b; }
+        if ((cached.C === null || cached.C === 0) && v.c) { cached.C = v.c; cached.D = v.d; }
       }
-      if (cached && cached.TYPE === null && MARINESIA_TYPE_MAP[typeKey] !== undefined) {
-        cached.TYPE = MARINESIA_TYPE_MAP[typeKey];
-      }
-      if (cached && !cached.IMO && v.imo) cached.IMO = v.imo;
-      if (cached && !cached.DEST && v.dest) cached.DEST = v.dest;
-      if (cached && !cached.DRAUGHT && v.draught) cached.DRAUGHT = v.draught;
-      if (cached && cached.A === null && v.a) { cached.A = v.a; cached.B = v.b; cached.C = v.c; cached.D = v.d; }
     }
 
     marinesiaLastPoll = new Date();

--- a/ais-proxy/server.js
+++ b/ais-proxy/server.js
@@ -1396,38 +1396,79 @@ async function pollMarinesia() {
     const body = await response.json();
     const vessels = body.data || [];
 
+    let added = 0;
     let enriched = 0;
     for (const v of vessels) {
       if (!v.mmsi) continue;
       const typeKey = (v.type || '').toLowerCase();
+      const mappedType = MARINESIA_TYPE_MAP[typeKey] ?? null;
+      const marinesiaTs = v.ts ? new Date(v.ts + 'Z') : new Date();
+
       marinesiaCache.set(v.mmsi, {
         name: v.name || '',
         imo: v.imo || null,
-        type: MARINESIA_TYPE_MAP[typeKey] ?? null,
+        type: mappedType,
         typeText: v.type || null,
         flag: v.flag || null,
         dest: v.dest || '',
         draught: v.draught || null,
-        callsign: '', // Marinesia doesn't provide callsign
+        callsign: '',
         a: v.a || null, b: v.b || null, c: v.c || null, d: v.d || null
       });
 
-      // Immediately enrich any cached vessel missing data
       const cached = vesselCache.get(v.mmsi);
       if (cached) {
-        if (!cached.NAME && v.name) {
-          cached.NAME = v.name;
-          cached._nameSource = 'marinesia';
-          enriched++;
-        }
-        if ((cached.TYPE === null || cached.TYPE === 0) && MARINESIA_TYPE_MAP[typeKey] !== undefined) {
-          cached.TYPE = MARINESIA_TYPE_MAP[typeKey];
-        }
+        // Enrich existing vessel with missing static data
+        if (!cached.NAME && v.name) { cached.NAME = v.name; cached._nameSource = 'marinesia'; enriched++; }
+        if ((cached.TYPE === null || cached.TYPE === 0) && mappedType !== null) cached.TYPE = mappedType;
         if (!cached.IMO && v.imo) cached.IMO = v.imo;
         if (!cached.DEST && v.dest) cached.DEST = v.dest;
         if (!cached.DRAUGHT && v.draught) cached.DRAUGHT = v.draught;
         if ((cached.A === null || cached.A === 0) && v.a) { cached.A = v.a; cached.B = v.b; }
         if ((cached.C === null || cached.C === 0) && v.c) { cached.C = v.c; cached.D = v.d; }
+        // Update position if Marinesia data is newer
+        if (marinesiaTs > cached.lastUpdate) {
+          cached.LATITUDE = v.lat;
+          cached.LONGITUDE = v.lng;
+          cached.COG = v.cog;
+          cached.SOG = v.sog;
+          cached.HEADING = v.hdt;
+          cached.NAVSTAT = v.status;
+          cached._rateOfTurn = v.rot;
+          cached.TIME = marinesiaTs.toISOString().replace('T', ' ').replace('Z', ' UTC');
+          cached.lastUpdate = marinesiaTs;
+        }
+      } else {
+        // Add new vessel from Marinesia
+        vesselCache.set(v.mmsi, {
+          MMSI: v.mmsi,
+          NAME: v.name || '',
+          CALLSIGN: '',
+          DEST: v.dest || '',
+          TYPE: mappedType,
+          IMO: v.imo || null,
+          DRAUGHT: v.draught || null,
+          A: v.a || null, B: v.b || null, C: v.c || null, D: v.d || null,
+          ETA: v.eta || null,
+          LATITUDE: v.lat,
+          LONGITUDE: v.lng,
+          COG: v.cog,
+          SOG: v.sog,
+          HEADING: v.hdt,
+          NAVSTAT: v.status,
+          TIME: marinesiaTs.toISOString().replace('T', ' ').replace('Z', ' UTC'),
+          lastUpdate: marinesiaTs,
+          _rateOfTurn: v.rot,
+          _positionAccuracy: null,
+          _timestamp: null,
+          _aisVersion: null,
+          _fixType: null,
+          _valid: null,
+          _messageType: 'PositionReport',
+          _nameSource: v.name ? 'marinesia' : null,
+          _dataSource: 'marinesia'
+        });
+        added++;
       }
     }
 
@@ -1436,7 +1477,7 @@ async function pollMarinesia() {
       marinesiaEnabled = true;
       console.log(`Marinesia enrichment enabled (${MARINESIA_POLL_INTERVAL/1000}s interval)`);
     }
-    console.log(`Marinesia: ${vessels.length} vessels fetched, ${enriched} names enriched, ${marinesiaCache.size} cached`);
+    console.log(`Marinesia: ${vessels.length} vessels fetched, ${added} added, ${enriched} enriched, ${marinesiaCache.size} cached`);
   } catch (error) {
     clearTimeout(timeoutId);
     if (error.name === 'AbortError') {

--- a/ais-proxy/server.js
+++ b/ais-proxy/server.js
@@ -35,7 +35,7 @@ const clientStatusCache = new Map(); // Track AIS upload clients
 const MAX_VESSEL_CACHE_SIZE = 50000;
 const MAX_RATE_LIMIT_CACHE_SIZE = 10000;
 const RATE_LIMIT_PER_MINUTE = 600;
-const MARINESIA_POLL_INTERVAL = parseInt(process.env.MARINESIA_POLL_INTERVAL) || 30000; // Configurable, default 30s
+const MARINESIA_DEFAULT_POLL_INTERVAL = 60000; // Default 60s, overridden by S3 config or env var
 const MARINESIA_BOUNDING_BOX = {
   lat_min: -48.0, lat_max: -34.0,
   long_min: 166.0, long_max: 179.0
@@ -1305,7 +1305,7 @@ app.get('/ais-proxy/v2/health', async (req, res) => {
         enabled: marinesiaEnabled,
         cachedVessels: marinesiaCache.size,
         lastPoll: marinesiaLastPoll ? marinesiaLastPoll.toISOString() : null,
-        pollInterval: MARINESIA_POLL_INTERVAL
+        pollInterval: marinesiaPollInterval
       },
       uploadClients: {
         totalClients: clientStatusCache.size,
@@ -1353,6 +1353,7 @@ const marinesiaCache = new Map(); // MMSI -> vessel data from Marinesia
 let marinesiaEnabled = false;
 let marinesiaLastPoll = null;
 let marinesiaInterval = null;
+let marinesiaPollInterval = MARINESIA_DEFAULT_POLL_INTERVAL;
 
 // Map Marinesia type text to AIS type codes
 const MARINESIA_TYPE_MAP = {
@@ -1475,7 +1476,7 @@ async function pollMarinesia() {
     marinesiaLastPoll = new Date();
     if (!marinesiaEnabled) {
       marinesiaEnabled = true;
-      console.log(`Marinesia enrichment enabled (${MARINESIA_POLL_INTERVAL/1000}s interval)`);
+      console.log(`Marinesia enrichment enabled (${marinesiaPollInterval/1000}s interval)`);
     }
     console.log(`Marinesia: ${vessels.length} vessels fetched, ${added} added, ${enriched} enriched, ${marinesiaCache.size} cached`);
   } catch (error) {
@@ -1489,14 +1490,16 @@ async function pollMarinesia() {
 }
 
 async function startMarinesiaEnrichment() {
-  const apiKey = await getMarinesiaKey();
+  const keys = await loadApiKeys();
+  const apiKey = keys.marinesia?.apiKey || process.env.MARINESIA_API_KEY;
   if (!apiKey) {
     console.log('Marinesia API key not configured, enrichment disabled');
     return;
   }
-  console.log(`Starting Marinesia enrichment (interval: ${MARINESIA_POLL_INTERVAL/1000}s)`);
+  marinesiaPollInterval = keys.marinesia?.pollInterval || parseInt(process.env.MARINESIA_POLL_INTERVAL) || MARINESIA_DEFAULT_POLL_INTERVAL;
+  console.log(`Starting Marinesia enrichment (interval: ${marinesiaPollInterval/1000}s)`);
   await pollMarinesia();
-  marinesiaInterval = setInterval(pollMarinesia, MARINESIA_POLL_INTERVAL);
+  marinesiaInterval = setInterval(pollMarinesia, marinesiaPollInterval);
 }
 
 app.listen(PORT, () => {

--- a/ais-proxy/server.js
+++ b/ais-proxy/server.js
@@ -35,6 +35,11 @@ const clientStatusCache = new Map(); // Track AIS upload clients
 const MAX_VESSEL_CACHE_SIZE = 50000;
 const MAX_RATE_LIMIT_CACHE_SIZE = 10000;
 const RATE_LIMIT_PER_MINUTE = 600;
+const MARINESIA_POLL_INTERVAL = parseInt(process.env.MARINESIA_POLL_INTERVAL) || 30000; // Configurable, default 30s
+const MARINESIA_BOUNDING_BOX = {
+  lat_min: -48.0, lat_max: -34.0,
+  long_min: 166.0, long_max: 179.0
+};
 
 // Sanitize log input to prevent log injection
 function sanitizeLogInput(input) {
@@ -78,6 +83,12 @@ async function loadApiKeys() {
 async function getAISStreamKey() {
   const keys = await loadApiKeys();
   return keys.aisstream?.primary?.key || keys.aisstream?.backup?.key;
+}
+
+// Get Marinesia API key
+async function getMarinesiaKey() {
+  const keys = await loadApiKeys();
+  return keys.marinesia?.apiKey || process.env.MARINESIA_API_KEY;
 }
 
 
@@ -336,7 +347,7 @@ function processAISMessage(message) {
       _fixType: null,
       _valid: null,
       _messageType: null,
-      _nameSource: null // 'ais' | null
+      _nameSource: null // 'ais' | 'marinesia' | null
     };
     
     // Update common fields
@@ -518,6 +529,26 @@ function processAISMessage(message) {
     }
     
     vesselCache.set(mmsi, vessel);
+    
+    // Enrich from Marinesia data if available
+    const marinesiaVessel = marinesiaCache.get(mmsi);
+    if (marinesiaVessel) {
+      if (!vessel.NAME && marinesiaVessel.name) {
+        vessel.NAME = marinesiaVessel.name;
+        vessel._nameSource = 'marinesia';
+      }
+      if (vessel.TYPE === null && marinesiaVessel.type !== null) {
+        vessel.TYPE = marinesiaVessel.type;
+      }
+      if (!vessel.IMO && marinesiaVessel.imo) vessel.IMO = marinesiaVessel.imo;
+      if (!vessel.CALLSIGN && marinesiaVessel.callsign) vessel.CALLSIGN = marinesiaVessel.callsign;
+      if (!vessel.DEST && marinesiaVessel.dest) vessel.DEST = marinesiaVessel.dest;
+      if (!vessel.DRAUGHT && marinesiaVessel.draught) vessel.DRAUGHT = marinesiaVessel.draught;
+      if (vessel.A === null && marinesiaVessel.a) vessel.A = marinesiaVessel.a;
+      if (vessel.B === null && marinesiaVessel.b) vessel.B = marinesiaVessel.b;
+      if (vessel.C === null && marinesiaVessel.c) vessel.C = marinesiaVessel.c;
+      if (vessel.D === null && marinesiaVessel.d) vessel.D = marinesiaVessel.d;
+    }
     
     // Save cache occasionally
     if (Math.random() < 0.01) saveCache();
@@ -1272,6 +1303,12 @@ app.get('/ais-proxy/v2/health', async (req, res) => {
         connected: wsConnection?.readyState === 1,
         reconnectAttempts
       },
+      marinesia: {
+        enabled: marinesiaEnabled,
+        cachedVessels: marinesiaCache.size,
+        lastPoll: marinesiaLastPoll ? marinesiaLastPoll.toISOString() : null,
+        pollInterval: MARINESIA_POLL_INTERVAL
+      },
       uploadClients: {
         totalClients: clientStatusCache.size,
         activeClients24h: Array.from(clientStatusCache.values())
@@ -1313,8 +1350,114 @@ process.on('SIGINT', () => {
   process.exit(0);
 });
 
+// Marinesia vessel enrichment
+const marinesiaCache = new Map(); // MMSI -> vessel data from Marinesia
+let marinesiaEnabled = false;
+let marinesiaLastPoll = null;
+let marinesiaInterval = null;
+
+// Map Marinesia type text to AIS type codes
+const MARINESIA_TYPE_MAP = {
+  'cargo': 70, 'tanker': 80, 'passenger': 60, 'fishing': 30,
+  'tug': 52, 'towing': 52, 'pilot': 50, 'pleasure craft': 37,
+  'sailing': 36, 'military': 35, 'search and rescue': 51,
+  'high speed craft': 40, 'dredging': 33, 'diving': 33,
+  'law enforcement': 55, 'wing in ground (wig)': 20
+};
+
+async function pollMarinesia() {
+  const apiKey = await getMarinesiaKey();
+  if (!apiKey) {
+    if (marinesiaEnabled) {
+      console.warn('Marinesia API key removed, disabling enrichment');
+      marinesiaEnabled = false;
+    }
+    return;
+  }
+
+  const { lat_min, lat_max, long_min, long_max } = MARINESIA_BOUNDING_BOX;
+  const url = `https://api.marinesia.com/api/v2/vessel/area?lat_min=${lat_min}&lat_max=${lat_max}&long_min=${long_min}&long_max=${long_max}&key=${apiKey}`;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 20000);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { 'Accept': 'application/json', 'User-Agent': 'ais-proxy/1.0' }
+    });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      console.warn(`Marinesia API returned ${response.status}`);
+      return;
+    }
+
+    const body = await response.json();
+    const vessels = body.data || [];
+
+    let enriched = 0;
+    for (const v of vessels) {
+      if (!v.mmsi) continue;
+      const typeKey = (v.type || '').toLowerCase();
+      marinesiaCache.set(v.mmsi, {
+        name: v.name || '',
+        imo: v.imo || null,
+        type: MARINESIA_TYPE_MAP[typeKey] ?? null,
+        typeText: v.type || null,
+        flag: v.flag || null,
+        dest: v.dest || '',
+        draught: v.draught || null,
+        callsign: '', // Marinesia doesn't provide callsign
+        a: v.a || null, b: v.b || null, c: v.c || null, d: v.d || null
+      });
+
+      // Immediately enrich any cached vessel missing data
+      const cached = vesselCache.get(v.mmsi);
+      if (cached && !cached.NAME && v.name) {
+        cached.NAME = v.name;
+        cached._nameSource = 'marinesia';
+        enriched++;
+      }
+      if (cached && cached.TYPE === null && MARINESIA_TYPE_MAP[typeKey] !== undefined) {
+        cached.TYPE = MARINESIA_TYPE_MAP[typeKey];
+      }
+      if (cached && !cached.IMO && v.imo) cached.IMO = v.imo;
+      if (cached && !cached.DEST && v.dest) cached.DEST = v.dest;
+      if (cached && !cached.DRAUGHT && v.draught) cached.DRAUGHT = v.draught;
+      if (cached && cached.A === null && v.a) { cached.A = v.a; cached.B = v.b; cached.C = v.c; cached.D = v.d; }
+    }
+
+    marinesiaLastPoll = new Date();
+    if (!marinesiaEnabled) {
+      marinesiaEnabled = true;
+      console.log(`Marinesia enrichment enabled (${MARINESIA_POLL_INTERVAL/1000}s interval)`);
+    }
+    console.log(`Marinesia: ${vessels.length} vessels fetched, ${enriched} names enriched, ${marinesiaCache.size} cached`);
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error.name === 'AbortError') {
+      console.warn('Marinesia poll timed out');
+    } else {
+      console.warn('Marinesia poll failed:', sanitizeLogInput(String(error.message)));
+    }
+  }
+}
+
+async function startMarinesiaEnrichment() {
+  const apiKey = await getMarinesiaKey();
+  if (!apiKey) {
+    console.log('Marinesia API key not configured, enrichment disabled');
+    return;
+  }
+  console.log(`Starting Marinesia enrichment (interval: ${MARINESIA_POLL_INTERVAL/1000}s)`);
+  await pollMarinesia();
+  marinesiaInterval = setInterval(pollMarinesia, MARINESIA_POLL_INTERVAL);
+}
+
 app.listen(PORT, () => {
   console.log(`AIS Proxy server running on port ${PORT}`);
   loadCache();
   connectToAISStream();
+  startMarinesiaEnrichment();
 });


### PR DESCRIPTION
### Problem
- VesselFinder API was blocking AWS IP ranges, causing all vessel name lookups to fail
- AISStream does not relay Class B static data (Message Type 24) for the NZ region, leaving ~130 Class B vessels without names
- Only 34% of vessels had names (97 out of 285)

### Solution
Integrate [Marinesia](https://marinesia.com) as a second data source alongside AISStream, providing vessel names, types, positions, and metadata for the NZ bounding box.

### Changes

**Marinesia integration** (`ais-proxy/server.js`)
- Poll Marinesia area API on a configurable interval (default 60s)
- Add vessels not seen by AISStream (~140 additional vessels)
- Enrich existing AISStream vessels with missing static data (name, type, IMO, dimensions, destination, draught)
- Update positions when Marinesia data is newer than cached data
- Both sources merged with latest-wins for position data, AIS always takes priority for static data

**Vessel classification fix**
- `_messageType` no longer overwritten by static data messages (`ShipStaticData`/`StaticDataReport`), fixing vessel misclassification as "other"
- AIS type `0` ("not available") and zero dimensions now treated as enrichable

**Type mapping**
- Complete Marinesia vessel type mapping to AIS codes (20 types including cargo, tanker, passenger, fishing, tug, sailing, pleasure craft, military, etc.)

**Configuration**
- Poll interval configurable via `marinesia.pollInterval` in S3 config file, with `MARINESIA_POLL_INTERVAL` env var fallback
- API key via S3 config (`marinesia.apiKey`) or `MARINESIA_API_KEY` env var
- Health endpoint shows Marinesia status (enabled, cached vessels, last poll, interval)

### Results
| Metric | Before | After |
|--------|--------|-------|
| Total vessels | 285 | 425 |
| Vessels with names | 97 (34%) | 392 (93%) |
| "Other" classification | 65-79 | 3 |
| Name sources | AIS only | AIS (99) + Marinesia (293) |

### S3 config example
```json
"marinesia": {
    "apiKey": "your-api-key",
    "pollInterval": 30000,
    "comment": "Marinesia API key for vessel enrichment",
    "enabled": true
}
