### PR TITLE
chore: bump ais-proxy image tag to v1.2.0

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -49,7 +49,7 @@
           "cpu": 256,
           "memory": 512,
           "priority": 2,
-          "imageTag": "v1.1.0"
+          "imageTag": "v1.2.0"
         },
         "power-outages": {
           "enabled": true,
@@ -133,7 +133,7 @@
           "cpu": 512,
           "memory": 1024,
           "priority": 2,
-          "imageTag": "v1.1.0"
+          "imageTag": "v1.2.0"
         },
         "power-outages": {
           "enabled": true,


### PR DESCRIPTION
Updates ais-proxy image tag for both dev-test and prod environments to include Marinesia integration and VesselFinder removal.