### PR TITLE
fix: add terrain-proxy imageTag and CI/CD path triggers

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - 'weather-proxy/**'
       - 'ais-proxy/**'
+      - 'power-outages/**'
       - 'tileserver-gl/**'
+      - 'terrain-proxy/**'
       - '**/Dockerfile'
       - 'cdk.json'
   workflow_call:

--- a/cdk.json
+++ b/cdk.json
@@ -84,6 +84,16 @@
               }
             ]
           }
+        },
+        "terrain-proxy": {
+          "enabled": true,
+          "path": "/terrain",
+          "healthCheckPath": "/terrain/health",
+          "port": 3000,
+          "cpu": 512,
+          "memory": 1024,
+          "priority": 5,
+          "imageTag": "v1.0.0"
         }
       },
       "general": {
@@ -168,6 +178,16 @@
               }
             ]
           }
+        },
+        "terrain-proxy": {
+          "enabled": true,
+          "path": "/terrain",
+          "healthCheckPath": "/terrain/health",
+          "port": 3000,
+          "cpu": 512,
+          "memory": 1024,
+          "priority": 5,
+          "imageTag": "v1.0.0"
         }
       },
       "general": {


### PR DESCRIPTION
- Add missing imageTag to terrain-proxy in both dev-test and prod environments
- Add terrain-proxy and power-outages to demo-build.yml path triggers