### PR TITLE
fix(terrain-proxy): rename manifest endpoint to t3-taknz-elevation-manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ MapTiler TileServer GL providing vector and raster tile services for New Zealand
 - **CloudFront CDN**: [CloudFront Setup](docs/CLOUDFRONT.md) with edge authentication
 - **API Keys**: Managed via CDK context or fallback defaults
 
+### terrain-proxy
+TAK terrain tile proxy that converts LINZ NZ elevation data into TAK-compatible terrain-RGB tiles for 3D rendering, line-of-sight analysis, and elevation profiles.
+
+- **Path**: `/terrain/*`
+- **Manifest**: `/terrain/t3-taknz-elevation-manifest.json`
+- **Health Check**: `/terrain/health`
+- **Data Source**: LINZ NZ Elevation (Terrain-RGB tiles)
+- **Coverage**: New Zealand (166°E–179°E, 48°S–34°S)
+- **Features**: EPSG:3857→4326 reprojection, Mapbox→TAK encoding, NZVD2016→HAE conversion
+- **Documentation**: [Terrain Proxy API](docs/TERRAIN_PROXY.md)
+
 
 
 ## Configuration

--- a/docs/TERRAIN_PROXY.md
+++ b/docs/TERRAIN_PROXY.md
@@ -16,7 +16,7 @@ Compared to the global TAK Bathy terrain dataset, this service provides:
 
 ### Terrain Manifest
 ```
-GET /terrain/manifest.json
+GET /terrain/t3-taknz-elevation-manifest.json
 ```
 Returns the TAK terrain tile descriptor. Point your TAK server or client at this URL to load NZ terrain.
 
@@ -42,7 +42,7 @@ GET /terrain/health
 ### ATAK / WinTAK
 Add as a terrain source using the manifest URL:
 ```
-https://utils.{domain}/terrain/manifest.json
+https://utils.{domain}/terrain/t3-taknz-elevation-manifest.json
 ```
 
 ### TAK Server

--- a/terrain-proxy/server.js
+++ b/terrain-proxy/server.js
@@ -276,7 +276,7 @@ async function generateTerrainTile(z, x, y) {
 // --- Routes ---
 
 // TAK terrain manifest — serves t3-taknz.json with {BASE_URL} replaced
-app.get('/terrain/manifest.json', (req, res) => {
+app.get('/terrain/t3-taknz-elevation-manifest.json', (req, res) => {
   const protocol = req.get('x-forwarded-proto') || req.protocol;
   const host = req.get('host');
   const baseUrl = `${protocol}://${host}`;


### PR DESCRIPTION
Rename /terrain/manifest.json to /terrain/t3-taknz-elevation-manifest.json for consistency with TAK terrain manifest naming conventions.

Updated server route, documentation, and README.