### PR TITLE
feat(terrain-proxy): add persistent S3 tile cache

### DIFF
--- a/lib/utils-infra-stack.ts
+++ b/lib/utils-infra-stack.ts
@@ -196,12 +196,17 @@ export class UtilsInfraStack extends cdk.Stack {
       );
     }
 
-    // Grant S3 access to config bucket for API keys
+    // Grant S3 access to config bucket for API keys and terrain tile cache
     const configBucketArn = Fn.importValue(createBaseImportValue(stackNameComponent, BASE_EXPORT_NAMES.ENV_CONFIG_BUCKET));
     taskRole.addToPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['s3:GetObject'],
       resources: [`${configBucketArn}/*`],
+    }));
+    taskRole.addToPolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['s3:PutObject'],
+      resources: [`${configBucketArn}/terrain-cache/*`],
     }));
     taskRole.addToPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
@@ -213,7 +218,7 @@ export class UtilsInfraStack extends cdk.Stack {
     const kmsKeyArn = Fn.importValue(createBaseImportValue(stackNameComponent, BASE_EXPORT_NAMES.KMS_KEY));
     taskRole.addToPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
-      actions: ['kms:Decrypt'],
+      actions: ['kms:Decrypt', 'kms:GenerateDataKey'],
       resources: [kmsKeyArn],
     }));
 

--- a/terrain-proxy/server.js
+++ b/terrain-proxy/server.js
@@ -3,7 +3,7 @@ const sharp = require('sharp');
 const NodeCache = require('node-cache');
 const fs = require('fs');
 const path = require('path');
-const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
+const { S3Client, GetObjectCommand, PutObjectCommand } = require('@aws-sdk/client-s3');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -14,12 +14,16 @@ const CONFIG_KEY = process.env.CONFIG_KEY || 'Utils-Terrain-Proxy-Config.json';
 
 let LINZ_API_KEY = process.env.LINZ_API_KEY || 'PLACEHOLDER_API_KEY';
 
-// Cache tiles for 24 hours (elevation data is static)
-const tileCache = new NodeCache({ stdTTL: 86400, maxKeys: 10000 });
+// Cache tiles: in-memory LRU for hot tiles, S3 for persistent storage
+const tileCache = new NodeCache({ stdTTL: 0, maxKeys: 50000 }); // No TTL, LRU eviction
 
 const TILE_SIZE = 256;
-const MAX_ZOOM = 14; // 14 levels: 0-13
+const MAX_ZOOM = 14;
 const NZ_BOUNDS = { minLat: -48.0, maxLat: -34.0, minLon: 166.0, maxLon: 179.0 };
+
+// S3 cache configuration
+const S3_CACHE_BUCKET = process.env.CONFIG_BUCKET;
+const S3_CACHE_PREFIX = 'terrain-cache/';
 
 // Load the static manifest template once at startup
 const manifestTemplate = fs.readFileSync(
@@ -44,6 +48,42 @@ async function loadConfigFromS3() {
     }
   } catch (error) {
     console.error('Failed to load config from S3:', error.message);
+  }
+}
+
+// --- S3 tile cache ---
+
+async function getFromS3Cache(cacheKey) {
+  if (!S3_CACHE_BUCKET) return null;
+  try {
+    const command = new GetObjectCommand({
+      Bucket: S3_CACHE_BUCKET,
+      Key: `${S3_CACHE_PREFIX}${cacheKey}.png`,
+    });
+    const response = await s3Client.send(command);
+    const chunks = [];
+    for await (const chunk of response.Body) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  } catch (err) {
+    if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) return null;
+    return null;
+  }
+}
+
+async function putToS3Cache(cacheKey, data) {
+  if (!S3_CACHE_BUCKET) return;
+  try {
+    await s3Client.send(new PutObjectCommand({
+      Bucket: S3_CACHE_BUCKET,
+      Key: `${S3_CACHE_PREFIX}${cacheKey}.png`,
+      Body: data,
+      ContentType: 'image/png',
+      CacheControl: 'public, max-age=31536000, immutable',
+    }));
+  } catch (err) {
+    // Non-fatal: cache write failure shouldn't break tile serving
   }
 }
 
@@ -199,12 +239,26 @@ async function getSeaLevelTile() {
 
 async function generateTerrainTile(z, x, y) {
   const cacheKey = `tak-${z}-${x}-${y}`;
-  const cached = tileCache.get(cacheKey);
-  if (cached) return cached;
+
+  // Tier 1: in-memory cache
+  const memCached = tileCache.get(cacheKey);
+  if (memCached) return memCached;
+
+  // Tier 2: S3 persistent cache
+  const s3Cached = await getFromS3Cache(cacheKey);
+  if (s3Cached) {
+    tileCache.set(cacheKey, s3Cached);
+    return s3Cached;
+  }
 
   const bounds = tileToLatLonBounds(z, x, y);
 
-  if (!tileOverlapsNZ(z, x, y)) return getSeaLevelTile();
+  if (!tileOverlapsNZ(z, x, y)) {
+    const tile = await getSeaLevelTile();
+    tileCache.set(cacheKey, tile);
+    putToS3Cache(cacheKey, tile); // async, don't await
+    return tile;
+  }
 
   // Pick a Mercator zoom that gives enough resolution
   const mercZoom = Math.min(z + 1, 18);
@@ -270,6 +324,7 @@ async function generateTerrainTile(z, x, y) {
   }).png({ compressionLevel: 6 }).toBuffer();
 
   tileCache.set(cacheKey, pngBuffer);
+  putToS3Cache(cacheKey, pngBuffer); // async, don't await
   return pngBuffer;
 }
 
@@ -291,6 +346,8 @@ app.get('/terrain/health', (req, res) => {
   res.json({
     status: 'ok',
     cache_keys: tileCache.keys().length,
+    cache_type: S3_CACHE_BUCKET ? 'memory+s3' : 'memory',
+    s3_cache_bucket: !!S3_CACHE_BUCKET,
     linz_api_configured: LINZ_API_KEY !== 'PLACEHOLDER_API_KEY',
     config_source: CONFIG_BUCKET ? 'S3' : 'environment',
     config_bucket: !!CONFIG_BUCKET,

--- a/test/utils-infra-stack.test.ts
+++ b/test/utils-infra-stack.test.ts
@@ -116,7 +116,7 @@ describe('UtilsInfraStack', () => {
         Statement: Match.arrayWith([
           Match.objectLike({
             Effect: 'Allow',
-            Action: 'kms:Decrypt'
+            Action: ['kms:Decrypt', 'kms:GenerateDataKey']
           })
         ])
       }


### PR DESCRIPTION
Add two-tier caching for terrain tiles:
- In-memory: 50k keys, no TTL, LRU eviction (hot tiles)
- S3: persistent across deployments, unlimited size (all tiles)

Tiles are stored under terrain-cache/ prefix in the existing config bucket. S3 writes are fire-and-forget to avoid slowing tile serving. On container restart, tiles are served from S3 and repopulate memory.

Also:
- Increased in-memory cache from 10k to 50k keys
- Removed 24h TTL (elevation data is static)
- Added s3:PutObject permission for terrain-cache/ prefix
- Added kms:GenerateDataKey for encrypted bucket writes
- Updated health endpoint with cache type info