### PR TITLE
feat(terrain-proxy): add CloudFront CDN with API key auth

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -87,7 +87,7 @@
         },
         "terrain-proxy": {
           "enabled": true,
-          "path": "/terrain",
+          "hostname": "terrain",
           "healthCheckPath": "/terrain/health",
           "port": 3000,
           "cpu": 512,
@@ -181,7 +181,7 @@
         },
         "terrain-proxy": {
           "enabled": true,
-          "path": "/terrain",
+          "hostname": "terrain",
           "healthCheckPath": "/terrain/health",
           "port": 3000,
           "cpu": 512,

--- a/lib/constructs/terrain-cloudfront.ts
+++ b/lib/constructs/terrain-cloudfront.ts
@@ -1,0 +1,153 @@
+/**
+ * CloudFront Construct - CDN for terrain-proxy
+ */
+import { Construct } from 'constructs';
+import {
+  aws_cloudfront as cloudfront,
+  aws_cloudfront_origins as origins,
+  aws_certificatemanager as acm,
+  aws_route53 as route53,
+  Duration,
+} from 'aws-cdk-lib';
+
+export interface TerrainCloudFrontProps {
+  albDomainName: string;
+  certificate: acm.ICertificate;
+  hostedZone: route53.IHostedZone;
+  hostname: string;
+  apiKeys: string[];
+}
+
+export class TerrainCloudFront extends Construct {
+  public readonly distribution: cloudfront.Distribution;
+  public readonly domainName: string;
+
+  constructor(scope: Construct, id: string, props: TerrainCloudFrontProps) {
+    super(scope, id);
+
+    const { albDomainName, certificate, hostedZone, hostname, apiKeys } = props;
+
+    const albOrigin = new origins.HttpOrigin(albDomainName, {
+      protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+    });
+
+    // Forward Host header so ALB routes correctly
+    const originRequestPolicy = new cloudfront.OriginRequestPolicy(this, 'OriginRequestPolicy', {
+      originRequestPolicyName: `Terrain-OriginRequest-${hostname}`,
+      headerBehavior: cloudfront.OriginRequestHeaderBehavior.allowList('Host'),
+      queryStringBehavior: cloudfront.OriginRequestQueryStringBehavior.all(),
+      cookieBehavior: cloudfront.OriginRequestCookieBehavior.none(),
+    });
+
+    // Terrain tiles are immutable — cache for 1 year
+    const tileCachePolicy = new cloudfront.CachePolicy(this, 'TileCachePolicy', {
+      cachePolicyName: `Terrain-Tiles-${hostname}`,
+      defaultTtl: Duration.days(365),
+      maxTtl: Duration.days(365),
+      minTtl: Duration.days(1),
+      headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+      queryStringBehavior: cloudfront.CacheQueryStringBehavior.none(),
+      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+    });
+
+    // Manifest — cache for 1 hour
+    const manifestCachePolicy = new cloudfront.CachePolicy(this, 'ManifestCachePolicy', {
+      cachePolicyName: `Terrain-Manifest-${hostname}`,
+      defaultTtl: Duration.minutes(5),
+      maxTtl: Duration.hours(1),
+      minTtl: Duration.seconds(0),
+      headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+      queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
+      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+    });
+
+    // Health — no cache
+    const noCachePolicy = new cloudfront.CachePolicy(this, 'NoCachePolicy', {
+      cachePolicyName: `Terrain-NoCache-${hostname}`,
+      defaultTtl: Duration.seconds(0),
+      maxTtl: Duration.seconds(1),
+      minTtl: Duration.seconds(0),
+      headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+      queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
+      cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+    });
+
+    // API key validation for terrain tile requests
+    const apiKeyFunction = new cloudfront.Function(this, 'ApiKeyFunction', {
+      functionName: `terrain-api-auth-${Date.now()}`,
+      code: cloudfront.FunctionCode.fromInline(`
+function handler(event) {
+    var request = event.request;
+
+    // Allow health without auth
+    if (request.uri === '/terrain/health') {
+        return request;
+    }
+
+    // Check for API key in query string
+    var querystring = request.querystring;
+    if (!querystring.api || !querystring.api.value) {
+        return {
+            statusCode: 401,
+            statusDescription: 'Unauthorized',
+            body: 'API key required'
+        };
+    }
+
+    var providedKey = querystring.api.value;
+    var validKeys = ${JSON.stringify(apiKeys)};
+
+    if (validKeys.indexOf(providedKey) === -1) {
+        return {
+            statusCode: 403,
+            statusDescription: 'Forbidden',
+            body: 'Invalid API key'
+        };
+    }
+
+    return request;
+}
+      `),
+    });
+
+    this.distribution = new cloudfront.Distribution(this, 'Distribution', {
+      domainNames: [`${hostname}.${hostedZone.zoneName}`],
+      certificate,
+      defaultBehavior: {
+        origin: albOrigin,
+        cachePolicy: manifestCachePolicy,
+        originRequestPolicy,
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
+        functionAssociations: [{
+          function: apiKeyFunction,
+          eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+        }],
+      },
+      additionalBehaviors: {
+        // Terrain tiles — cache aggressively
+        '/terrain/*.png': {
+          origin: albOrigin,
+          cachePolicy: tileCachePolicy,
+          originRequestPolicy,
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
+          functionAssociations: [{
+            function: apiKeyFunction,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          }],
+        },
+        // Health — no cache, no auth
+        '/terrain/health': {
+          origin: albOrigin,
+          cachePolicy: noCachePolicy,
+          originRequestPolicy,
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
+        },
+      },
+    });
+
+    this.domainName = this.distribution.distributionDomainName;
+  }
+}

--- a/lib/utils-infra-stack.ts
+++ b/lib/utils-infra-stack.ts
@@ -14,6 +14,7 @@ import { SecurityGroups } from './constructs/security-groups';
 import { Alb } from './constructs/alb';
 import { ContainerService } from './constructs/container-service';
 import { CloudFront } from './constructs/cloudfront';
+import { TerrainCloudFront } from './constructs/terrain-cloudfront';
 import { ApiAuth } from './constructs/api-auth';
 
 // Utility imports
@@ -196,17 +197,12 @@ export class UtilsInfraStack extends cdk.Stack {
       );
     }
 
-    // Grant S3 access to config bucket for API keys and terrain tile cache
+    // Grant S3 access to config bucket for API keys
     const configBucketArn = Fn.importValue(createBaseImportValue(stackNameComponent, BASE_EXPORT_NAMES.ENV_CONFIG_BUCKET));
     taskRole.addToPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ['s3:GetObject'],
       resources: [`${configBucketArn}/*`],
-    }));
-    taskRole.addToPolicy(new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      actions: ['s3:PutObject'],
-      resources: [`${configBucketArn}/terrain-cache/*`],
     }));
     taskRole.addToPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
@@ -218,7 +214,7 @@ export class UtilsInfraStack extends cdk.Stack {
     const kmsKeyArn = Fn.importValue(createBaseImportValue(stackNameComponent, BASE_EXPORT_NAMES.KMS_KEY));
     taskRole.addToPolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
-      actions: ['kms:Decrypt', 'kms:GenerateDataKey'],
+      actions: ['kms:Decrypt'],
       resources: [kmsKeyArn],
     }));
 
@@ -405,6 +401,45 @@ export class UtilsInfraStack extends cdk.Stack {
             value: cloudFront.domainName,
             description: 'CloudFront distribution domain name',
             exportName: `${id}-CloudFrontDomain`,
+          });
+        } else if (containerName === 'terrain-proxy') {
+          // Create CloudFront distribution for terrain proxy
+          const terrainCfCert = new acm.DnsValidatedCertificate(this, 'TerrainCloudFrontCertificate', {
+            domainName: `${containerConfig.hostname}.${hostedZone.zoneName}`,
+            hostedZone,
+            region: 'us-east-1',
+          });
+
+          const apiKeys = this.node.tryGetContext('apiKeys') || [];
+
+          const terrainCloudFront = new TerrainCloudFront(this, 'TerrainCloudFront', {
+            albDomainName: alb.dnsName,
+            certificate: terrainCfCert,
+            hostedZone,
+            hostname: containerConfig.hostname,
+            apiKeys,
+          });
+
+          new route53.ARecord(this, `${containerName}ARecord`, {
+            zone: hostedZone,
+            recordName: containerConfig.hostname,
+            target: route53.RecordTarget.fromAlias(
+              new targets.CloudFrontTarget(terrainCloudFront.distribution)
+            ),
+          });
+
+          new route53.AaaaRecord(this, `${containerName}AaaaRecord`, {
+            zone: hostedZone,
+            recordName: containerConfig.hostname,
+            target: route53.RecordTarget.fromAlias(
+              new targets.CloudFrontTarget(terrainCloudFront.distribution)
+            ),
+          });
+
+          new cdk.CfnOutput(this, 'TerrainCloudFrontDomain', {
+            value: terrainCloudFront.domainName,
+            description: 'Terrain CloudFront distribution domain name',
+            exportName: `${id}-TerrainCloudFrontDomain`,
           });
         } else {
           // Create Route53 record for hostname (direct ALB)

--- a/terrain-proxy/server.js
+++ b/terrain-proxy/server.js
@@ -3,7 +3,7 @@ const sharp = require('sharp');
 const NodeCache = require('node-cache');
 const fs = require('fs');
 const path = require('path');
-const { S3Client, GetObjectCommand, PutObjectCommand } = require('@aws-sdk/client-s3');
+const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -14,16 +14,12 @@ const CONFIG_KEY = process.env.CONFIG_KEY || 'Utils-Terrain-Proxy-Config.json';
 
 let LINZ_API_KEY = process.env.LINZ_API_KEY || 'PLACEHOLDER_API_KEY';
 
-// Cache tiles: in-memory LRU for hot tiles, S3 for persistent storage
-const tileCache = new NodeCache({ stdTTL: 0, maxKeys: 50000 }); // No TTL, LRU eviction
+// Cache tiles in memory (elevation data is static)
+const tileCache = new NodeCache({ stdTTL: 0, maxKeys: 50000 });
 
 const TILE_SIZE = 256;
 const MAX_ZOOM = 14;
 const NZ_BOUNDS = { minLat: -48.0, maxLat: -34.0, minLon: 166.0, maxLon: 179.0 };
-
-// S3 cache configuration
-const S3_CACHE_BUCKET = process.env.CONFIG_BUCKET;
-const S3_CACHE_PREFIX = 'terrain-cache/';
 
 // Load the static manifest template once at startup
 const manifestTemplate = fs.readFileSync(
@@ -48,42 +44,6 @@ async function loadConfigFromS3() {
     }
   } catch (error) {
     console.error('Failed to load config from S3:', error.message);
-  }
-}
-
-// --- S3 tile cache ---
-
-async function getFromS3Cache(cacheKey) {
-  if (!S3_CACHE_BUCKET) return null;
-  try {
-    const command = new GetObjectCommand({
-      Bucket: S3_CACHE_BUCKET,
-      Key: `${S3_CACHE_PREFIX}${cacheKey}.png`,
-    });
-    const response = await s3Client.send(command);
-    const chunks = [];
-    for await (const chunk of response.Body) {
-      chunks.push(chunk);
-    }
-    return Buffer.concat(chunks);
-  } catch (err) {
-    if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) return null;
-    return null;
-  }
-}
-
-async function putToS3Cache(cacheKey, data) {
-  if (!S3_CACHE_BUCKET) return;
-  try {
-    await s3Client.send(new PutObjectCommand({
-      Bucket: S3_CACHE_BUCKET,
-      Key: `${S3_CACHE_PREFIX}${cacheKey}.png`,
-      Body: data,
-      ContentType: 'image/png',
-      CacheControl: 'public, max-age=31536000, immutable',
-    }));
-  } catch (err) {
-    // Non-fatal: cache write failure shouldn't break tile serving
   }
 }
 
@@ -239,24 +199,14 @@ async function getSeaLevelTile() {
 
 async function generateTerrainTile(z, x, y) {
   const cacheKey = `tak-${z}-${x}-${y}`;
-
-  // Tier 1: in-memory cache
-  const memCached = tileCache.get(cacheKey);
-  if (memCached) return memCached;
-
-  // Tier 2: S3 persistent cache
-  const s3Cached = await getFromS3Cache(cacheKey);
-  if (s3Cached) {
-    tileCache.set(cacheKey, s3Cached);
-    return s3Cached;
-  }
+  const cached = tileCache.get(cacheKey);
+  if (cached) return cached;
 
   const bounds = tileToLatLonBounds(z, x, y);
 
   if (!tileOverlapsNZ(z, x, y)) {
     const tile = await getSeaLevelTile();
     tileCache.set(cacheKey, tile);
-    putToS3Cache(cacheKey, tile); // async, don't await
     return tile;
   }
 
@@ -324,7 +274,6 @@ async function generateTerrainTile(z, x, y) {
   }).png({ compressionLevel: 6 }).toBuffer();
 
   tileCache.set(cacheKey, pngBuffer);
-  putToS3Cache(cacheKey, pngBuffer); // async, don't await
   return pngBuffer;
 }
 
@@ -332,10 +281,17 @@ async function generateTerrainTile(z, x, y) {
 
 // TAK terrain manifest — serves t3-taknz.json with {BASE_URL} replaced
 app.get('/terrain/t3-taknz-elevation-manifest.json', (req, res) => {
+  const apiKey = req.query.api;
+  if (!apiKey) {
+    return res.status(401).json({ error: 'API key required', message: 'Use ?api=your-key' });
+  }
+
   const protocol = req.get('x-forwarded-proto') || req.protocol;
   const host = req.get('host');
   const baseUrl = `${protocol}://${host}`;
-  const manifest = manifestTemplate.replace('{BASE_URL}', baseUrl);
+  const manifest = manifestTemplate
+    .replace('{BASE_URL}', baseUrl)
+    .replace('{API_KEY}', apiKey);
 
   res.set({ 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=3600' });
   res.send(manifest);
@@ -346,8 +302,6 @@ app.get('/terrain/health', (req, res) => {
   res.json({
     status: 'ok',
     cache_keys: tileCache.keys().length,
-    cache_type: S3_CACHE_BUCKET ? 'memory+s3' : 'memory',
-    s3_cache_bucket: !!S3_CACHE_BUCKET,
     linz_api_configured: LINZ_API_KEY !== 'PLACEHOLDER_API_KEY',
     config_source: CONFIG_BUCKET ? 'S3' : 'environment',
     config_bucket: !!CONFIG_BUCKET,

--- a/terrain-proxy/t3-taknz.json
+++ b/terrain-proxy/t3-taknz.json
@@ -5,7 +5,7 @@
   "downloadable": true,
   "refreshInterval": 0,
   "isQuadtree": true,
-  "url": "{BASE_URL}/terrain/{$z}/{$x}/{$y}.png",
+  "url": "{BASE_URL}/terrain/{$z}/{$x}/{$y}.png?api={API_KEY}",
   "srs": "EPSG:4326",
   "numLevels": 14,
   "tileMatrix": [

--- a/test/utils-infra-stack.test.ts
+++ b/test/utils-infra-stack.test.ts
@@ -116,7 +116,7 @@ describe('UtilsInfraStack', () => {
         Statement: Match.arrayWith([
           Match.objectLike({
             Effect: 'Allow',
-            Action: ['kms:Decrypt', 'kms:GenerateDataKey']
+            Action: 'kms:Decrypt'
           })
         ])
       }


### PR DESCRIPTION
Replace S3 tile cache with CloudFront CDN for terrain proxy, following the same pattern as tileserver-gl:

- New terrain.{domain} hostname with dedicated CloudFront distribution
- API key authentication via CloudFront Function (reuses tileserver keys)
- Aggressive tile caching (365 days, immutable elevation data)
- Manifest cached 1 hour, health endpoint uncached
- Switch terrain-proxy from path-based (/terrain/*) to hostname-based routing

Changes:
- Add TerrainCloudFront construct (lib/constructs/terrain-cloudfront.ts)
- Switch cdk.json terrain-proxy from path to hostname routing (both envs)
- Wire up CloudFront + Route53 + certificate in utils-infra-stack.ts
- Remove S3 cache code from terrain-proxy/server.js (CloudFront handles it)
- Keep in-memory cache (50k keys, no TTL) as origin-level buffer
- Revert S3 PutObject/KMS GenerateDataKey permissions (no longer needed)