### PR TITLE
chore(terrain-proxy): bump imageTag to v1.0.1

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -93,7 +93,7 @@
           "cpu": 512,
           "memory": 1024,
           "priority": 5,
-          "imageTag": "v1.0.0"
+          "imageTag": "v1.0.1"
         }
       },
       "general": {
@@ -187,7 +187,7 @@
           "cpu": 512,
           "memory": 1024,
           "priority": 5,
-          "imageTag": "v1.0.0"
+          "imageTag": "v1.0.1"
         }
       },
       "general": {


### PR DESCRIPTION
Bump terrain-proxy imageTag from v1.0.0 to v1.0.1 for both dev-test and prod environments.