### PR TITLE
Feat/ais-proxy-v1.2.3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+audit-level=high

--- a/ais-proxy/server.js
+++ b/ais-proxy/server.js
@@ -1439,6 +1439,7 @@ async function pollMarinesia() {
 
   const { lat_min, lat_max, long_min, long_max } = MARINESIA_BOUNDING_BOX;
   const url = `https://api.marinesia.com/api/v2/vessel/area?lat_min=${lat_min}&lat_max=${lat_max}&long_min=${long_min}&long_max=${long_max}&key=${apiKey}`;
+  const keyHint = apiKey.slice(-4);
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 20000);
@@ -1451,7 +1452,7 @@ async function pollMarinesia() {
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      console.warn(`Marinesia API returned ${response.status}`);
+      console.warn(`Marinesia API returned ${response.status} (key: ...${keyHint})`);
       return;
     }
 
@@ -1543,7 +1544,7 @@ async function pollMarinesia() {
       marinesiaEnabled = true;
       console.log(`Marinesia enrichment enabled (${marinesiaPollInterval/1000}s interval)`);
     }
-    console.log(`Marinesia: ${vessels.length} vessels fetched, ${added} added, ${enriched} enriched, ${marinesiaCache.size} cached`);
+    console.log(`Marinesia: ${vessels.length} vessels fetched, ${added} added, ${enriched} enriched, ${marinesiaCache.size} cached (key: ...${keyHint})`);
   } catch (error) {
     clearTimeout(timeoutId);
     if (error.name === 'AbortError') {
@@ -1562,7 +1563,8 @@ async function startMarinesiaEnrichment() {
     return;
   }
   marinesiaPollInterval = keys.marinesia?.pollInterval || parseInt(process.env.MARINESIA_POLL_INTERVAL) || MARINESIA_DEFAULT_POLL_INTERVAL;
-  console.log(`Starting Marinesia enrichment (interval: ${marinesiaPollInterval/1000}s)`);
+  const keyHint = apiKey.slice(-4);
+  console.log(`Starting Marinesia enrichment (interval: ${marinesiaPollInterval/1000}s, key: ...${keyHint})`);
   await pollMarinesia();
   marinesiaInterval = setInterval(pollMarinesia, marinesiaPollInterval);
 }

--- a/cdk.json
+++ b/cdk.json
@@ -49,7 +49,7 @@
           "cpu": 256,
           "memory": 512,
           "priority": 2,
-          "imageTag": "v1.2.2"
+          "imageTag": "v1.2.3"
         },
         "power-outages": {
           "enabled": true,
@@ -142,7 +142,7 @@
           "cpu": 512,
           "memory": 1024,
           "priority": 2,
-          "imageTag": "v1.2.2"
+          "imageTag": "v1.2.3"
         },
         "power-outages": {
           "enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,49 +9,49 @@
       "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "aws-cdk-lib": "^2.235.1",
+        "aws-cdk-lib": "^2.258.0",
         "constructs": "^10.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.5",
         "@types/node": "20.6.2",
-        "aws-cdk": "^2.235.1",
+        "aws-cdk": "^2.1126.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
         "typescript": "~5.2.2"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.273",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
-      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.17.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.17.0.tgz",
-      "integrity": "sha512-JB9L4JCbZeYbMJPs7OKV+7YaxKwk4i2tlI5PCSfCzk4DJvprhCO2TYcqbqo3Y1YWZyyY/SEPLWdorG7b88fUSA==",
+      "version": "54.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
+      "integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.1"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -59,7 +59,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1118.4",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1118.4.tgz",
-      "integrity": "sha512-wJfRQdvb+FJ2cni059mYdmjhfwhMskP+PAB59BL9jhon+jYtjy8X3pbj3uzHgAOJwNhh6jGkP8xq36Cffccbbw==",
+      "version": "2.1126.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1126.0.tgz",
+      "integrity": "sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1165,9 +1165,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.250.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.250.0.tgz",
-      "integrity": "sha512-8U8/S9VcmKSc3MHZWiB7P0IecgXoohI8Ya3dgtZMgbzC4mB+MEQmsYBeNgm4vzGQdRos8HjQLnFX1IBlZh7jQA==",
+      "version": "2.258.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.258.0.tgz",
+      "integrity": "sha512-OfFfg30ikBRJ3dimlzsWhPIrj6qug1p2XYsdB38CtMtcur7SufzoUczgI6kWjbQkOVcQgYzhzN29DErV0yZG7A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -1184,19 +1184,19 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.0",
-        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.5",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.1",
         "table": "^6.9.0",
         "yaml": "1.10.3"
       },
@@ -1208,41 +1208,18 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.0",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.5",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -1251,7 +1228,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1304,7 +1281,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1349,7 +1326,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",
@@ -1364,7 +1341,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1403,7 +1380,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1476,7 +1453,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   "devDependencies": {
     "@types/jest": "^29.5.5",
     "@types/node": "20.6.2",
-    "aws-cdk": "^2.235.1",
+    "aws-cdk": "^2.1126.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.235.1",
+    "aws-cdk-lib": "^2.258.0",
     "constructs": "^10.0.0"
   },
   "keywords": [


### PR DESCRIPTION
fast-uri <=3.1.1 is vulnerable to path traversal (GHSA-q3j6-qgpj-74h6) and host confusion (GHSA-v39h-62p7-jpjc). brace-expansion 5.0.2-5.0.5 has a moderate DoS issue (GHSA-jxxr-4gwj-5jf2). Both are bundled inside aws-cdk-lib and cannot be overridden externally.

Also bumps aws-cdk CLI to ^2.1126.0 and adds .npmrc with audit-level=high to match the pattern used in auth-infra and tak-infra.