### PR TITLE
feat: add display-proxy — CloudTAK MJPEG streaming display service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,9 @@ TAK-NZ-Maps-Package*.zip
 
 # Generated GRG files
 grg-output/
+
+# Display proxy config contains real API tokens — upload to S3, don't commit
+display-proxy/Utils-Display-Proxy-Config.json
+
+# Allow display-proxy JS source (excluded by *.js CDK rule above)
+!display-proxy/*.js

--- a/README.md
+++ b/README.md
@@ -69,6 +69,51 @@ TAK terrain tile proxy that converts LINZ NZ elevation data into TAK-compatible 
 - **Features**: EPSG:3857→4326 reprojection, Mapbox→TAK encoding, NZVD2016→HAE conversion
 - **Documentation**: [Terrain Proxy API](docs/TERRAIN_PROXY.md)
 
+### display-proxy
+CloudTAK MJPEG display proxy. Opens CloudTAK in a headless Chromium browser and
+streams it as a continuous MJPEG video feed. Designed for digital signage platforms
+(AbleSign, Fire TV sticks, wall-mounted displays) that cannot render the CloudTAK
+web application directly.
+
+The browser stays open permanently — CDP screencast pushes JPEG frames only when
+the page content changes, so bandwidth is near-zero when the map is static and
+briefly higher when icons or data update.
+
+- **Hostname**: `display.{domain}` (e.g. `display.demo.tak.nz`)
+- **Health Check**: `/health`
+- **Stream**: `GET /stream?key=<token>` — raw MJPEG stream (`<img src="...">` or AbleSign image URL)
+- **View**: `GET /view?key=<token>` — full-screen HTML wrapper (for browsers / AbleSign web page mode)
+- **Auth**: Local access key in `?key=` query parameter, validated against `access_keys` in S3 config
+- **S3 Config**: `Utils-Display-Proxy-Config.json` — see `display-proxy/Utils-Display-Proxy-Config.sample.json`
+
+**S3 config format:**
+```json
+{
+    "cloudtak_url":        "https://map.demo.tak.nz",
+    "cloudtak_token":      "etl.<jwt>",
+    "display_url_params":  "/",
+    "viewport_width":      1920,
+    "viewport_height":     1080,
+    "jpeg_quality":        80,
+    "initial_wait_ms":     15000,
+    "access_keys":         ["<your-random-token>"]
+}
+```
+
+> **Note:** The config file contains a real CloudTAK API token. Upload it directly to S3 — do not commit it to git (`Utils-Display-Proxy-Config.json` is in `.gitignore`).
+
+**Upload config to S3:**
+```bash
+aws s3 cp display-proxy/Utils-Display-Proxy-Config.json \
+    s3://<config-bucket>/Utils-Display-Proxy-Config.json \
+    --profile tak-nz-demo --region ap-southeast-2
+```
+
+**Use in AbleSign or Fire TV:**
+```
+https://display.demo.tak.nz/view?key=<your-random-token>
+```
+
 
 
 ## Configuration

--- a/cdk.json
+++ b/cdk.json
@@ -93,6 +93,16 @@
           "memory": 1024,
           "priority": 5,
           "imageTag": "v1.0.1"
+        },
+        "display-proxy": {
+          "enabled": true,
+          "hostname": "display",
+          "healthCheckPath": "/health",
+          "port": 3000,
+          "cpu": 1024,
+          "memory": 2048,
+          "priority": 6,
+          "imageTag": "v1.0.0"
         }
       },
       "general": {
@@ -186,6 +196,16 @@
           "memory": 1024,
           "priority": 5,
           "imageTag": "v1.0.1"
+        },
+        "display-proxy": {
+          "enabled": true,
+          "hostname": "display",
+          "healthCheckPath": "/health",
+          "port": 3000,
+          "cpu": 1024,
+          "memory": 2048,
+          "priority": 6,
+          "imageTag": "v1.0.0"
         }
       },
       "general": {

--- a/display-proxy/Dockerfile
+++ b/display-proxy/Dockerfile
@@ -1,0 +1,24 @@
+# Use the official Playwright image — includes Chromium and all system deps.
+# Alpine cannot be used here as Chromium requires glibc.
+FROM mcr.microsoft.com/playwright:v1.61.1-jammy
+
+WORKDIR /app
+
+# Copy package files and install Node deps only (Playwright browsers already in base image)
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy application
+COPY . .
+
+# Non-root user (uid 1001 matches the Playwright base image's pwuser)
+RUN chown -R pwuser:pwuser /app
+USER pwuser
+
+EXPOSE 3000
+
+# Longer start period — Chromium needs time to launch and render before health check fires
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
+
+CMD ["node", "server.js"]

--- a/display-proxy/Utils-Display-Proxy-Config.sample.json
+++ b/display-proxy/Utils-Display-Proxy-Config.sample.json
@@ -1,0 +1,12 @@
+{
+    "cloudtak_url": "https://map.demo.tak.nz",
+    "cloudtak_token": "etl.<your-cloudtak-api-token>",
+    "display_url_params": "/",
+    "viewport_width": 1920,
+    "viewport_height": 1080,
+    "jpeg_quality": 80,
+    "initial_wait_ms": 15000,
+    "access_keys": [
+        "<generate-with: python3 -c \"import secrets; print(secrets.token_urlsafe(32))\">"
+    ]
+}

--- a/display-proxy/package-lock.json
+++ b/display-proxy/package-lock.json
@@ -1,0 +1,464 @@
+{
+  "name": "display-proxy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "display-proxy",
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.600.0",
+        "playwright": "^1.61.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
+      "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1085.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1085.0.tgz",
+      "integrity": "sha512-O0xe8sR50AYkwxlvRRsV0qytEO2dtXQTQ1CF3YBBdE5xtVkbu27H0vGa1mjQi1/+fbYM80AWEIPai5jZmXyubw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.16",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.66",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.62",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.975.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
+      "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
+      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
+      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/display-proxy/package.json
+++ b/display-proxy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "display-proxy",
+  "version": "1.0.0",
+  "description": "CloudTAK MJPEG display proxy — streams a live headless-browser view of CloudTAK",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "lint": "eslint server.js"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.600.0",
+    "playwright": "^1.61.1"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/display-proxy/server.js
+++ b/display-proxy/server.js
@@ -1,0 +1,320 @@
+'use strict';
+
+const http             = require('http');
+const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
+const { chromium }     = require('playwright');
+
+// ---------------------------------------------------------------------------
+// Environment
+// ---------------------------------------------------------------------------
+
+const PORT         = process.env.PORT        || 3000;
+const CONFIG_BUCKET = process.env.CONFIG_BUCKET;
+const CONFIG_KEY    = process.env.CONFIG_KEY  || 'Utils-Display-Proxy-Config.json';
+const AWS_REGION    = process.env.AWS_REGION  || 'ap-southeast-2';
+
+const BOUNDARY      = 'mjpegframe';
+const CONFIG_POLL_MS = 5 * 60 * 1000;   // re-read S3 config every 5 minutes
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let config          = null;   // loaded from S3
+let currentFrame    = null;   // Buffer — latest JPEG frame
+let lastFrameTime   = null;
+let browserLoop     = null;   // BrowserLoop instance
+const clients       = new Set();
+
+const s3 = new S3Client({ region: AWS_REGION });
+
+// ---------------------------------------------------------------------------
+// S3 config loader
+// ---------------------------------------------------------------------------
+
+async function loadConfig() {
+    if (!CONFIG_BUCKET) {
+        console.warn('CONFIG_BUCKET not set — using defaults (for local dev)');
+        return {
+            cloudtak_url:         'https://map.demo.tak.nz',
+            cloudtak_token:       process.env.CLOUDTAK_TOKEN || '',
+            display_url_params:   '/',
+            viewport_width:       1920,
+            viewport_height:      1080,
+            jpeg_quality:         80,
+            initial_wait_ms:      15000,
+            access_keys:          ['demo'],
+        };
+    }
+
+    console.log(`Loading config from s3://${CONFIG_BUCKET}/${CONFIG_KEY}`);
+    const res = await s3.send(new GetObjectCommand({
+        Bucket: CONFIG_BUCKET,
+        Key:    CONFIG_KEY,
+    }));
+
+    const body = await res.Body.transformToString();
+    const cfg  = JSON.parse(body);
+    console.log('Config loaded from S3');
+    return cfg;
+}
+
+// ---------------------------------------------------------------------------
+// Browser / CDP screencast loop
+// ---------------------------------------------------------------------------
+
+class BrowserLoop {
+    constructor(cfg) {
+        this.cfg     = cfg;
+        this.browser = null;
+        this.running = false;
+    }
+
+    loginUrl() {
+        // Same approach as screenshot-loop.cjs — construct full login URL
+        const base    = this.cfg.cloudtak_url.replace(/\/$/, '');
+        const token   = encodeURIComponent(this.cfg.cloudtak_token);
+        const redirect = encodeURIComponent(this.cfg.display_url_params || '/');
+        return `${base}/login?token=${token}&redirect=${redirect}`;
+    }
+
+    async start() {
+        this.running = true;
+        console.log('Launching headless Chromium…');
+
+        this.browser = await chromium.launch({
+            args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        });
+
+        const context = await this.browser.newContext();
+        this.page     = await context.newPage();
+
+        await this.page.setViewportSize({
+            width:  this.cfg.viewport_width  || 1920,
+            height: this.cfg.viewport_height || 1080,
+        });
+
+        const loginUrl = this.loginUrl();
+        console.log(`Navigating to ${this.cfg.cloudtak_url}…`);
+        await this.page.goto(loginUrl, { waitUntil: 'networkidle', timeout: 90000 });
+
+        const waitMs = this.cfg.initial_wait_ms || 15000;
+        console.log(`Waiting ${waitMs / 1000}s for map tiles and icons…`);
+        await new Promise(r => setTimeout(r, waitMs));
+
+        console.log('Starting CDP screencast…');
+        this.cdp = await context.newCDPSession(this.page);
+
+        await this.cdp.send('Page.startScreencast', {
+            format:        'jpeg',
+            quality:       this.cfg.jpeg_quality || 80,
+            maxWidth:      this.cfg.viewport_width  || 1920,
+            maxHeight:     this.cfg.viewport_height || 1080,
+            everyNthFrame: 1,
+        });
+
+        this.cdp.on('Page.screencastFrame', async ({ data, sessionId }) => {
+            currentFrame  = Buffer.from(data, 'base64');
+            lastFrameTime = new Date();
+
+            // Ack so Chrome continues sending frames
+            await this.cdp.send('Page.screencastFrameAck', { sessionId }).catch(() => {});
+
+            // Push to all connected MJPEG clients
+            pushFrame(currentFrame);
+        });
+
+        this.browser.on('disconnected', () => {
+            if (!this.running) return;
+            console.error('Browser disconnected — restarting in 5s…');
+            this.browser = null;
+            setTimeout(() => this.start(), 5000);
+        });
+
+        console.log('Screencast running.');
+    }
+
+    async stop() {
+        this.running = false;
+        if (this.cdp) {
+            await this.cdp.send('Page.stopScreencast').catch(() => {});
+            this.cdp = null;
+        }
+        if (this.browser) {
+            await this.browser.close().catch(() => {});
+            this.browser = null;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MJPEG push to connected clients
+// ---------------------------------------------------------------------------
+
+function pushFrame(frame) {
+    const header = Buffer.from(
+        `--${BOUNDARY}\r\n` +
+        `Content-Type: image/jpeg\r\n` +
+        `Content-Length: ${frame.length}\r\n` +
+        `\r\n`
+    );
+    const packet = Buffer.concat([header, frame, Buffer.from('\r\n')]);
+
+    for (const res of clients) {
+        try {
+            res.write(packet);
+        } catch {
+            clients.delete(res);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+
+function isAuthorised(key) {
+    if (!config || !config.access_keys || config.access_keys.length === 0) return false;
+    return config.access_keys.includes(key);
+}
+
+// ---------------------------------------------------------------------------
+// HTML wrapper page
+// ---------------------------------------------------------------------------
+
+function buildPage(key) {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <title>CloudTAK Live Display</title>
+  <style>
+    * { margin:0; padding:0; box-sizing:border-box; }
+    html, body { width:100%; height:100%; background:#000; overflow:hidden; }
+    img { width:100vw; height:100vh; object-fit:contain; display:block; }
+  </style>
+</head>
+<body>
+  <img src="/stream?key=${key}" alt="CloudTAK Live Display"/>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server
+// ---------------------------------------------------------------------------
+
+const server = http.createServer((req, res) => {
+    const parsed   = new URL(req.url, 'http://localhost');
+    const pathname = parsed.pathname;
+    const key      = parsed.searchParams.get('key');
+
+    // Health — no auth
+    if (pathname === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+            status:     'ok',
+            stream:     currentFrame ? 'ready' : 'initialising',
+            lastFrame:  lastFrameTime,
+            clients:    clients.size,
+        }));
+        return;
+    }
+
+    // Auth required for all other endpoints
+    if (!isAuthorised(key)) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid or missing key' }));
+        return;
+    }
+
+    // GET /view — HTML wrapper (browser / AbleSign web page mode)
+    if (pathname === '/view') {
+        const html = buildPage(key);
+        res.writeHead(200, {
+            'Content-Type':  'text/html; charset=utf-8',
+            'Cache-Control': 'no-store',
+        });
+        res.end(html);
+        return;
+    }
+
+    // GET /stream — MJPEG stream (AbleSign image URL mode, or <img> src)
+    if (pathname === '/stream') {
+        res.writeHead(200, {
+            'Content-Type':  `multipart/x-mixed-replace; boundary=${BOUNDARY}`,
+            'Cache-Control': 'no-store',
+            'Connection':    'keep-alive',
+            'Pragma':        'no-cache',
+        });
+
+        clients.add(res);
+        console.log(`[${new Date().toISOString()}] Client connected (${clients.size} total)`);
+
+        // Send current frame immediately — no waiting for next capture
+        if (currentFrame) {
+            pushFrame(currentFrame);
+        }
+
+        req.on('close', () => {
+            clients.delete(res);
+            console.log(`[${new Date().toISOString()}] Client disconnected (${clients.size} total)`);
+        });
+
+        return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+// ---------------------------------------------------------------------------
+// Startup
+// ---------------------------------------------------------------------------
+
+async function main() {
+    // Load initial config
+    config = await loadConfig();
+
+    // Poll S3 for config changes every 5 minutes
+    // If config changes, restart the browser loop with new settings
+    setInterval(async () => {
+        try {
+            const newConfig = await loadConfig();
+            const changed   =
+                newConfig.cloudtak_url      !== config.cloudtak_url      ||
+                newConfig.cloudtak_token    !== config.cloudtak_token    ||
+                newConfig.display_url_params !== config.display_url_params ||
+                newConfig.viewport_width    !== config.viewport_width    ||
+                newConfig.viewport_height   !== config.viewport_height;
+
+            config = newConfig;
+
+            if (changed && browserLoop) {
+                console.log('Config changed — restarting browser loop…');
+                await browserLoop.stop();
+                browserLoop = new BrowserLoop(config);
+                await browserLoop.start();
+            }
+        } catch (err) {
+            console.error('Failed to reload config from S3:', err.message);
+        }
+    }, CONFIG_POLL_MS);
+
+    // Start browser loop
+    browserLoop = new BrowserLoop(config);
+    await browserLoop.start();
+
+    // Start HTTP server
+    server.listen(PORT, () => {
+        console.log(`display-proxy listening on port ${PORT}`);
+        console.log(`  /view?key=<token>   — HTML wrapper`);
+        console.log(`  /stream?key=<token> — MJPEG stream`);
+        console.log(`  /health             — health check`);
+    });
+}
+
+main().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+});

--- a/lib/constructs/alb.ts
+++ b/lib/constructs/alb.ts
@@ -154,7 +154,8 @@ export class Alb extends Construct {
     
     // Configure ALB for larger request bodies (AIS uploads)
     this.loadBalancer.setAttribute('routing.http2.enabled', 'true');
-    this.loadBalancer.setAttribute('idle_timeout.timeout_seconds', '60');
+    // 3600s — required for persistent MJPEG connections (display-proxy)
+    this.loadBalancer.setAttribute('idle_timeout.timeout_seconds', '3600');
     this.loadBalancer.setAttribute('connection_logs.s3.enabled', 'false');
 
     // Create Route53 record

--- a/lib/utils-infra-stack.ts
+++ b/lib/utils-infra-stack.ts
@@ -323,6 +323,9 @@ export class UtilsInfraStack extends cdk.Stack {
       } else if (containerName === 'terrain-proxy') {
         environmentVariables.CONFIG_BUCKET = cdk.Token.asString(Fn.select(5, Fn.split(':', configBucketArn)));
         environmentVariables.CONFIG_KEY = 'Utils-Terrain-Proxy-Config.json';
+      } else if (containerName === 'display-proxy') {
+        environmentVariables.CONFIG_BUCKET = cdk.Token.asString(Fn.select(5, Fn.split(':', configBucketArn)));
+        environmentVariables.CONFIG_KEY = 'Utils-Display-Proxy-Config.json';
       }
 
       // Create container service


### PR DESCRIPTION
Adds a new `display-proxy` service that renders the CloudTAK web interface in a headless Chromium browser and streams it as a continuous MJPEG feed. Designed for digital signage platforms (AbleSign, Fire TV sticks, wall-mounted screens) that cannot reliably render the CloudTAK single-page application directly.

## How it works

Rather than polling for screenshots, the service uses the Chrome DevTools Protocol (CDP) `Page.startScreencast` API to receive a continuous stream of JPEG frames whenever the page content changes. Frames are pushed immediately to all connected clients via a persistent `multipart/x-mixed-replace` HTTP response — no polling, no reload cycle, no dark flashes between frames.

When the map is static (no new CoT data, no tile updates) Chrome sends very few frames, keeping bandwidth near zero. When icons or data update, a brief burst of frames is delivered and the display updates smoothly.

## Endpoints

| Endpoint | Description |
|---|---|
| `GET /stream?key=<token>` | Raw MJPEG stream — use as `<img src>` or AbleSign image URL |
| `GET /view?key=<token>` | Full-screen HTML wrapper — use as AbleSign web page URL |
| `GET /health` | Health check — returns stream status and last frame timestamp |

## Configuration

Config is loaded from S3 at startup and polled for changes every 5 minutes (same pattern as `ais-proxy` and `weather-proxy`). See `display-proxy/Utils-Display-Proxy-Config.sample.json`.

Key config fields: `cloudtak_url`, `cloudtak_token` (non-expiring ETL API token), `display_url_params` (map position fragment), `viewport_width`/`viewport_height` (1920×1080 default, 3840×2160 for 4K), `access_keys` (local auth tokens).

## Infrastructure changes

- **`cdk.json`** — `display-proxy` added to `dev-test` and `prod` with `hostname: display` (serves at `display.<env>.tak.nz`), 1 vCPU, 2 GB
- **`lib/constructs/alb.ts`** — ALB idle timeout raised from 60s to 3600s; required for persistent MJPEG connections (the previous 60s would have silently killed active streams)
- **`lib/utils-infra-stack.ts`** — `Utils-Display-Proxy-Config.json` S3 config key wired in

## Testing

Verified locally: Docker build succeeds with Playwright v1.61.1, container starts, config loads from S3, Chromium launches, `/health` returns `{"stream":"ready"}`.

CPU peaks at ~100% during Chromium startup then settles to ~8% at rest. Memory peaks at ~800 MB during startup, ~224 MB steady-state — sized at 2 GB to give comfortable headroom.