### PR TITLE
fix: display-proxy — correct URL encoding for map position redirect

### DIFF
--- a/display-proxy/Utils-Display-Proxy-Config.sample.json
+++ b/display-proxy/Utils-Display-Proxy-Config.sample.json
@@ -1,7 +1,7 @@
 {
     "cloudtak_url": "https://map.demo.tak.nz",
     "cloudtak_token": "etl.<your-cloudtak-api-token>",
-    "display_url_params": "/",
+    "display_url_params": "/%236/-41.29/174.78",
     "viewport_width": 1920,
     "viewport_height": 1080,
     "jpeg_quality": 80,

--- a/display-proxy/server.js
+++ b/display-proxy/server.js
@@ -71,10 +71,13 @@ class BrowserLoop {
     }
 
     loginUrl() {
-        // Same approach as screenshot-loop.cjs — construct full login URL
-        const base    = this.cfg.cloudtak_url.replace(/\/$/, '');
-        const token   = encodeURIComponent(this.cfg.cloudtak_token);
-        const redirect = encodeURIComponent(this.cfg.display_url_params || '/');
+        // Construct the CloudTAK login URL with token and redirect.
+        // display_url_params should be stored pre-encoded in config
+        // (e.g. "/%236/-41.29/174.78" not "/#6/-41.29/174.78")
+        // since the # must be %23 in the redirect query parameter.
+        const base     = this.cfg.cloudtak_url.replace(/\/$/, '');
+        const token    = encodeURIComponent(this.cfg.cloudtak_token);
+        const redirect = this.cfg.display_url_params || '/';
         return `${base}/login?token=${token}&redirect=${redirect}`;
     }
 


### PR DESCRIPTION
Fixes an incorrect double-encoding of the `display_url_params` config value when constructing the CloudTAK login URL.

## Problem

The `loginUrl()` method was calling `encodeURIComponent()` on the `display_url_params` value from the S3 config. When a map position fragment is specified (e.g. `/%236/-41.29/174.78`), this caused the `%23` to be double-encoded to `%2523`, breaking the redirect after login.

```
// Before — double-encodes the value
const redirect = encodeURIComponent(this.cfg.display_url_params || '/');
// → &redirect=%2F%25236%2F-41.29%2F174.78  ❌
```

## Fix

Pass `display_url_params` through directly without encoding. The value in the S3 config must already be correctly pre-encoded — specifically, `#` must be stored as `%23` since it appears inside a query parameter value.

```
// After — passed through as-is
const redirect = this.cfg.display_url_params || '/';
// → &redirect=/%236/-41.29/174.78  ✅
```

## Config format

To set a specific map position, store the pre-encoded fragment in S3:

```json
"display_url_params": "/%236/-41.29/174.78"
```

This corresponds to zoom level 6 centred on Wellington — `/#6/-41.29/174.78` after the login redirect resolves. The sample config has been updated to reflect this format.

## No rebuild required

This is a documentation/config clarification. The fix to `server.js` is in the source file but does not change the deployed container since the image tag is unchanged — the fix takes effect when the container is next rebuilt and deployed.