### PR TITLE
fix: display-proxy — prevent black screen when map is idle

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -102,7 +102,7 @@
           "cpu": 1024,
           "memory": 2048,
           "priority": 6,
-          "imageTag": "v1.0.0"
+          "imageTag": "v1.0.1"
         }
       },
       "general": {
@@ -205,7 +205,7 @@
           "cpu": 1024,
           "memory": 2048,
           "priority": 6,
-          "imageTag": "v1.0.0"
+          "imageTag": "v1.0.1"
         }
       },
       "general": {

--- a/display-proxy/server.js
+++ b/display-proxy/server.js
@@ -127,6 +127,22 @@ class BrowserLoop {
             pushFrame(currentFrame);
         });
 
+        // Fallback: if Chrome goes idle (no visual changes), force a screenshot
+        // every 30 seconds so connected clients always get a fresh frame
+        this.fallbackTimer = setInterval(async () => {
+            const idleMs = lastFrameTime ? Date.now() - lastFrameTime.getTime() : Infinity;
+            if (idleMs > 25000) {
+                try {
+                    const buf = await this.page.screenshot({ type: 'jpeg', quality: this.cfg.jpeg_quality || 80 });
+                    currentFrame  = buf;
+                    lastFrameTime = new Date();
+                    pushFrame(currentFrame);
+                } catch (err) {
+                    // page may be navigating — ignore
+                }
+            }
+        }, 30000);
+
         this.browser.on('disconnected', () => {
             if (!this.running) return;
             console.error('Browser disconnected — restarting in 5s…');
@@ -139,6 +155,10 @@ class BrowserLoop {
 
     async stop() {
         this.running = false;
+        if (this.fallbackTimer) {
+            clearInterval(this.fallbackTimer);
+            this.fallbackTimer = null;
+        }
         if (this.cdp) {
             await this.cdp.send('Page.stopScreencast').catch(() => {});
             this.cdp = null;


### PR DESCRIPTION
Fixes a black screen issue on `display.*.tak.nz/stream` that occurs when the CloudTAK map has no visual activity.

## Problem

The CDP `Page.startScreencast` API only pushes JPEG frames when Chrome detects a visual change on the page. When the map is fully static — no new CoT data arriving, no tile reloads, no animations — Chrome sends zero frames. Any client that connects during a quiet period receives the MJPEG stream headers but no frame data, showing a permanent black screen until something on the map changes.

In practice this happens frequently: the map can be static for many minutes at a time between CoT updates.

## Fix

Adds a 30-second interval fallback timer that forces a `page.screenshot()` call if no CDP frame has been received in the last 25 seconds. The screenshot is pushed to all connected clients as a regular MJPEG frame.

This ensures:
- New clients connecting during a quiet period get a frame within 30 seconds at most
- Long-running connections never go black indefinitely
- The CDP screencast still delivers smooth real-time updates when the map is active — the fallback only kicks in during idle periods

## Behaviour

| Condition | Frame source | Max latency to client |
|---|---|---|
| Map actively changing | CDP screencast | Near-instant |
| Map idle < 25s | Last CDP frame sent on connect | Instant |
| Map idle > 25s | Fallback `page.screenshot()` | ≤ 30 seconds |

## Changes

- `display-proxy/server.js` — adds `fallbackTimer` interval in `BrowserLoop.start()`, clears it in `BrowserLoop.stop()`
- `cdk.json` — bumps `imageTag` to `v1.0.1` in both `dev-test` and `prod`